### PR TITLE
GitHub: Add missing environment secrets for publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment: Sonatype
     env:
+      ORG_GRADLE_PROJECT_sonatypePass: ${{ secrets.SONATYPE_API_KEY }}
+      ORG_GRADLE_PROJECT_sonatypeUser: ${{ secrets.SONATYPE_USER }}
       SONATYPE_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
       SONATYPE_GPG_KEY_PASSWORD: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
-      SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,16 +1,10 @@
 #!/bin/bash
 #
-# Script to publish libary in case a release commit is discovered
+# Script to publish a library in case a release commit is discovered
 #
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "${SCRIPT_DIR}/inc.functions.sh"
-
-# Constants
-SECRET_FILE=buildSrc/src/main/kotlin/Secrets.kt
-
-# Checks
-[[ -f ${SECRET_FILE} ]] || die "Publish requires credentials at '${SECRET_FILE}'"
 
 # Functions
 function is_release_commit() {


### PR DESCRIPTION
Finish up 'Replace GPG-encrypted secrets with Gradle properties' refactoring.