### PR TITLE
Update Gradle Wrapper to version 8.12.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description

This pull request upgrades the Gradle Wrapper to version 8.12.1, updating distribution files and wrapper scripts to align with the latest Gradle changes. Added SPDX license identifiers to scripts and adjusted path references for improved consistency and compatibility.

For detailed changes, refer to the [Gradle 8.12.1 release notes](https://docs.gradle.org/8.12.1/release-notes.html).

### Checklist

- [x] Tested changes locally
- [x] Updated relevant documentation
- [x] Verified compatibility with the application