### PR TITLE
Bump com.diffplug.spotless from 7.1.0 to 7.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.2.20" apply false
     id("com.android.library") version "8.7.3" apply false
-    id("com.diffplug.spotless") version "7.1.0"
+    id("com.diffplug.spotless") version "7.2.1"
     id("com.github.ben-manes.versions") version "0.52.0"
 }
 


### PR DESCRIPTION
Bumps com.diffplug.spotless from 7.1.0 to 7.2.1.

---
updated-dependencies:
- dependency-name: com.diffplug.spotless dependency-version: 7.2.1 dependency-type: direct:production update-type: version-update:semver-minor ...